### PR TITLE
Update GNOME runtime to version 47

### DIFF
--- a/com.github.taiko2k.avvie.json
+++ b/com.github.taiko2k.avvie.json
@@ -1,7 +1,7 @@
 {
   "app-id": "com.github.taiko2k.avvie",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "46",
+  "runtime-version": "47",
   "sdk": "org.gnome.Sdk",
   "command": "avvie",
   "finish-args": [


### PR DESCRIPTION
GNOME runtime version 46 will reach EOL on 2025-03-15.

Source: https://release.gnome.org/calendar/